### PR TITLE
chore: cors /api/** url 만 받을 수 있도록 설정

### DIFF
--- a/src/main/java/banzzac/WebMvcConfig.java
+++ b/src/main/java/banzzac/WebMvcConfig.java
@@ -10,9 +10,9 @@ public class WebMvcConfig implements WebMvcConfigurer{
 	@Override
 	public void addCorsMappings(CorsRegistry registry) {
 		System.out.println("WebMvcConfig 실행");
-		registry.addMapping("/**").allowedOrigins("http://localhost:5173")
+		registry.addMapping("/api/**").allowedOrigins("http://localhost:5173")
 		.allowedMethods("GET", "POST")
-        .allowedHeaders("Authorization", "Content-Type")
+        .allowedHeaders("Authorization", "Content-Type")	
         .exposedHeaders("Custom-Header")
         .allowCredentials(true)
         .maxAge(3600);


### PR DESCRIPTION

REST Controller의 @RequsetBody("/api/내가 쓸 URL")
api 필수 입력.
front에서 axios로 요청시 url에 api가 필수적으로 붙어야함.

ex) axios.get("http://localhost/api/member")
 
